### PR TITLE
fix: rule file names are off by one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+[2025/02/01] - Bug fix - Rule file names were off by one. (hayabusa#1555) (@fukusuket)
+
 [2024/10/29] - Fixed a panic bug due to multiple YAML files being contained in a single file. (#4) (@fukusuket)
 
 [2024/10/03] - Rules config files are now combined into a single file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,15 +28,13 @@ fn merge_yaml_files(files: Vec<String>) -> Result<String, Box<dyn std::error::Er
         merged_yaml.push((file, content));
     }
     let mut out_str = String::new();
-    for (i, (file, docs)) in merged_yaml.iter().enumerate() {
-        if i > 0 {
-            out_str.push_str("\nrulefile: ");
-            let re = Regex::new(r".*/").unwrap();
-            out_str.push_str(&re.replace(file, ""));
-            out_str.push('\n');
-            out_str.push_str("---\n");
-        }
-        out_str.push_str(docs)
+    for (file, docs) in merged_yaml.iter() {
+        out_str.push_str(docs);
+        out_str.push_str("\nrulefile: ");
+        let re = Regex::new(r".*/").unwrap();
+        out_str.push_str(&re.replace(file, ""));
+        out_str.push('\n');
+        out_str.push_str("---\n");
     }
     Ok(out_str)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,13 +28,15 @@ fn merge_yaml_files(files: Vec<String>) -> Result<String, Box<dyn std::error::Er
         merged_yaml.push((file, content));
     }
     let mut out_str = String::new();
-    for (file, docs) in merged_yaml.iter() {
+    for (i, (file, docs)) in merged_yaml.iter().enumerate() {
         out_str.push_str(docs);
         out_str.push_str("\nrulefile: ");
         let re = Regex::new(r".*/").unwrap();
         out_str.push_str(&re.replace(file, ""));
-        out_str.push('\n');
-        out_str.push_str("---\n");
+        if i < merged_yaml.len() - 1 {
+            out_str.push('\n');
+            out_str.push_str("---\n");
+        }
     }
     Ok(out_str)
 }


### PR DESCRIPTION
## What changed
- Closed https://github.com/Yamato-Security/hayabusa/issues/1555

## Fixed  rule file(decoded)
[decoded_rules.yml.txt](https://github.com/user-attachments/files/18627288/decoded_rules.yml.txt)

## Fixed  rule file(encoded)
[encoded_rules.yml.txt](https://github.com/user-attachments/files/18627289/encoded_rules.yml.txt)

I would appreciate it if you could check it out when you have time🙏