### PR TITLE
fix: changed rulefile field value to absolute file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+[2025/02/10] - Bug fix - Number of rules enabled after channel filtering differed between live response and standard hayabusa. (hayabusa#1557) (@fukusuket)
+
 [2025/02/01] - Bug fix - Rule file names were off by one. (hayabusa#1555) (@fukusuket)
 
 [2024/10/29] - Fixed a panic bug due to multiple YAML files being contained in a single file. (#4) (@fukusuket)

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn merge_yaml_files(files: Vec<String>) -> Result<String, Box<dyn std::error::Er
     for (i, (file, docs)) in merged_yaml.iter().enumerate() {
         out_str.push_str(docs);
         out_str.push_str("\nrulefile: ");
-        let re = Regex::new(r".*/").unwrap();
+        let re = Regex::new(r".*hayabusa-rules/").unwrap();
         out_str.push_str(&re.replace(file, ""));
         if i < merged_yaml.len() - 1 {
             out_str.push('\n');


### PR DESCRIPTION
## What changed
- Closed https://github.com/Yamato-Security/hayabusa/issues/1557

## Changed behavior
The Channel filter was not working as expected because the `rulefile` field was only a file name, as shown below.
(For example, the following rule will generate two rules, sysmon and builtin. But only one rule was filtered.)

before:
```yml
title: Suspicious Encoded Scripts in a WMI Consumer
id: 18aa5578-4930-e3f7-01d6-49277db69f4f
...
rulefile: sysmon_wmi_susp_encoded_scripts.yml
```

after:
```yml
title: Suspicious Encoded Scripts in a WMI Consumer
id: 18aa5578-4930-e3f7-01d6-49277db69f4f
...
rulefile: sigma/sysmon/wmi_event/sysmon_wmi_susp_encoded_scripts.yml
```

## Fixed  rule file(decoded)
[decoded_rules.yml.txt](https://github.com/user-attachments/files/18717270/decoded_rules.yml.txt)

## Fixed  rule file(encoded)
[encoded_rules.yml.txt](https://github.com/user-attachments/files/18717271/encoded_rules.yml.txt)

I would appreciate it if you could check it out when you have time🙏