### PR TITLE
fix: output rulefile when multiple yaml

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,13 +25,16 @@ fn merge_yaml_files(files: Vec<String>) -> Result<String, Box<dyn std::error::Er
     for file in &files {
         let mut content = String::new();
         File::open(file)?.read_to_string(&mut content)?;
-        merged_yaml.push((file, content));
+        let s = content.to_string();
+        for c in s.split("---\n") {
+            merged_yaml.push((file, c.to_string()));
+        }
     }
     let mut out_str = String::new();
+    let re = Regex::new(r".*hayabusa-rules/").unwrap();
     for (i, (file, docs)) in merged_yaml.iter().enumerate() {
         out_str.push_str(docs);
         out_str.push_str("\nrulefile: ");
-        let re = Regex::new(r".*hayabusa-rules/").unwrap();
         out_str.push_str(&re.replace(file, ""));
         if i < merged_yaml.len() - 1 {
             out_str.push('\n');


### PR DESCRIPTION
## What changed
- Closed https://github.com/Yamato-Security/hayabusa/issues/1572

## Fixed  rule file(decoded)
[decoded_rules.yml.txt](https://github.com/user-attachments/files/18784337/decoded_rules.yml.txt)

## Fixed  rule file(encoded)
[encoded_rules.yml.txt](https://github.com/user-attachments/files/18784339/encoded_rules.yml.txt)


I would appreciate it if you could check it out when you have time🙏