### PR TITLE
fix: exclude expand modifier rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+[2025/02/26] - `expand` rules are not being filtered out as they cannot be used for live response and require manual configuration beforehand. (hayabusa#1596) (@fukusuket)
+
 [2025/02/14] - Bug fix - The `RulePath` was blank in the encoded rules when there were multiple rules in a single file. (hayabusa#1572) (@fukusuket)
 
 [2025/02/10] - Bug fix - Number of rules enabled after channel filtering differed between live response and standard hayabusa. (hayabusa#1557) (@fukusuket)

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,9 @@ fn merge_yaml_files(files: Vec<String>) -> Result<String, Box<dyn std::error::Er
         let mut content = String::new();
         File::open(file)?.read_to_string(&mut content)?;
         let s = content.to_string();
+        if s.contains("|expand: ") {
+            continue;
+        }
         for c in s.split("---\n") {
             merged_yaml.push((file, c.to_string()));
         }


### PR DESCRIPTION
## What changed
- Related https://github.com/Yamato-Security/hayabusa/issues/1596

## Fixed  rule file(decoded)
[decoded_rules.yml.txt](https://github.com/user-attachments/files/18965178/decoded_rules.yml.txt)

## Fixed  rule file(encoded)
[encoded_rules.yml.txt](https://github.com/user-attachments/files/18965182/encoded_rules.yml.txt)

I would appreciate it if you could check it out when you have time🙏