### PR TITLE
fix: remove processing for `ignore-uuid-list.txt` in GitHub Actions

### DIFF
--- a/.github/workflows/create-encoded-package.yml
+++ b/.github/workflows/create-encoded-package.yml
@@ -46,7 +46,6 @@ jobs:
         run: |
           cd sigma-to-hayabusa-converter
           poetry install --no-root
-          sed -i.bak '/^[^#]/d' ignore-uuid-list.txt
           poetry run python sigma-to-hayabusa-converter.py -r ../sigma-repo -o converted_rules
           cd -
           rm -rf hayabusa-rules/sigma/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+[2025/03/01] - Bug fix - The encoded rules file included rules that are supposed to be ignored by `ignore-uuid-list.txt`. (hayabusa#1596) (@fukusuket)
+
 [2025/02/26] - `expand` rules are not being filtered out as they cannot be used for live response and require manual configuration beforehand. (hayabusa#1596) (@fukusuket)
 
 [2025/02/14] - Bug fix - The `RulePath` was blank in the encoded rules when there were multiple rules in a single file. (hayabusa#1572) (@fukusuket)


### PR DESCRIPTION
## What changed
- Closed https://github.com/Yamato-Security/hayabusa/issues/1596

### Cause of Issue #1596
The following rules are excluded from the `hayabusa_rules` repository by the [ignore-uuid-list.txt](https://github.com/Yamato-Security/sigma-to-hayabusa-converter/blob/main/ignore-uuid-list.txt#L6).
- https://github.com/SigmaHQ/sigma/blob/5711c8a2f4ab93f6b1643d3b804f70a56bf72421/rules/windows/wmi_event/sysmon_wmi_event_subscription.yml#L2

However, the GitHub Actions for `hayabusa-encoded-rules` included this rule because [it was designed to remove ignore-uuid-list.txt](https://github.com/Yamato-Security/hayabusa-encoded-rules/pull/10/commits/b4efa746ea9cebc1a52e91b4c77f910adc704b0a). Therefore, this process has been removed.

## Fixed  rule file(decoded)
[decoded_rules.yml.txt](https://github.com/user-attachments/files/19038431/decoded_rules.yml.txt)

## Fixed  rule file(encoded)
[encoded_rules.yml.txt](https://github.com/user-attachments/files/19038433/encoded_rules.yml.txt)

I would appreciate it if you could check it out when you have time🙏